### PR TITLE
feat: Make ticket system usage generic

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -12,7 +12,15 @@ When this command is run with a state management file as $ARGUMENTS.
 
 1. Read state management file to understand the context for what you need to review
 
-2. Update Linear issue status to "Code Review" using `linear:update_issue`
+2. Update issue status to "Code Review" - run the .claude/commands/ticket-update-issue.md command, passing the issue key and new status as arguments to it
+
+Get the issue key from the state management file in $ARGUMENTS.
+
+Format the arguments as:
+```
+Ticket Number: [issue key from state management file]
+New Status: Code Review
+```
 
 3. Read the specification linked in the state management file
 
@@ -33,7 +41,13 @@ When this command is run with a state management file as $ARGUMENTS.
 
 7. Final verdict: APPROVED or NEEDS_CHANGES with clear reasons
 
-8. Once APPROVED, add a comment to the Linear issue describing the findings and verdict, using `linear:create_comment`
+8. Once APPROVED, add code review comment - run the .claude/commands/ticket-create-comment.md command, passing the issue key and findings as arguments to it
+
+Format the arguments as:
+```
+Ticket Number: [issue key from state management file]
+Comment Text: [code review findings and verdict]
+```
 
 9. Report DONE to the orchestrating command.
 
@@ -69,6 +83,22 @@ Provide structured feedback:
 - **Next Steps**: Actionable items
 - **Decision**: APPROVED or NEEDS_CHANGES
 
-**Update Linear issue based on decision**:
-- If APPROVED: Update status to "Ready For Human Review"
-- If NEEDS_CHANGES: Update status to "In Progress" and add comment with required changes
+**Update issue status based on decision**:
+- If APPROVED: run the .claude/commands/ticket-update-issue.md command with status "Ready For Human Review"
+- If NEEDS_CHANGES: run the .claude/commands/ticket-update-issue.md command with status "In Progress" and run the .claude/commands/ticket-create-comment.md command with required changes
+
+Format the arguments as:
+```
+Ticket Number: [issue key from state management file]
+New Status: Ready For Human Review
+```
+or
+```
+Ticket Number: [issue key from state management file]
+New Status: In Progress
+```
+and
+```
+Ticket Number: [issue key from state management file]
+Comment Text: [required changes description]
+```

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -8,7 +8,7 @@ You are responsible for making sure all steps are done according to the workflow
 All steps MUST complete, and they must be completed in the order described below.
 You are only allowed to move to the next step after the previous step has reported DONE.
 
-The Linear issue key for the feature to implement is in $ARGUMENTS.
+The issue key for the feature to implement is in $ARGUMENTS.
 
 IMPORTANT: The workflow steps will report to you when they're done, and only then can the next step start. Do not stop until the workflow is completed.
 Create a TODO list for the workflow steps, and follow it.
@@ -17,7 +17,7 @@ Create a TODO list for the workflow steps, and follow it.
 
 1. Read `CLAUDE.md`: General principles, quality gates, and development workflow
 2. Create a state management file for this increment - run the .claude/commands/create-state-management-file.md command, passing $ARGUMENTS as argument to it
-3. Read Linear Issue - run the .claude/commands/read-issue.md command, passing the state management file as argument to it
+3. Read issue - run the .claude/commands/read-issue.md command, passing the state management file as argument to it
 4. Define implementation plan - run the .claude/commands/define-implementation-plan.md command, passing the state management file as argument to it
 5. Write specification - run the .claude/commands/write-specification.md command, passing the state management file as argument to it
 6. Get sign-off on specification. You are not allowed to go to step 7 until the user has signed off on the specification. Run the .claude/commands/specification-signoff.md command, passing the state management file as argument to it
@@ -29,7 +29,7 @@ Repeat as needed.
 11. Create pull request - run the .claude/commands/create-pull-request.md command, passing the state management file as argument to it
 12. Review pull request - run the .claude/commands/review-pull-request.md command, passing the state management file as argument to it
 
-**If Linear operations fail**:
+**If ticket system operations fail**:
 - Continue with local specification files
-- Log Linear errors but don't block development
-- Manually update Linear status if needed
+- Log ticket system errors but don't block development
+- Manually update ticket status if needed

--- a/.claude/commands/implement-increment.md
+++ b/.claude/commands/implement-increment.md
@@ -8,18 +8,32 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 
 ## Workflow Steps
 
-1. Update Linear issue status:
-- Set status to "In Progress" using `linear:update_issue`. List statuses using `linear:list_issue_statuses` if needed.
-- Add comment: "Claude Code implementation started for {name of specification file linked in $ARGUMENTS}"
+1. Update issue status to "In Progress" - run the .claude/commands/ticket-update-issue.md command, passing the issue key and new status as arguments to it
 
-2. Understand the division of work and spawn sub-agents:
+Get the issue key from the state management file in $ARGUMENTS.
+
+Format the arguments as:
+```
+Ticket Number: [issue key from state management file]
+New Status: In Progress
+```
+
+2. Add implementation comment - run the .claude/commands/ticket-create-comment.md command, passing the issue key and comment as arguments to it
+
+Format the arguments as:
+```
+Ticket Number: [issue key from state management file]
+Comment Text: Claude Code implementation started for {name of specification file linked in $ARGUMENTS}
+```
+
+3. Understand the division of work and spawn sub-agents:
    a. Read specification to identify agent_ids
    b. For each agent_id: spawn a sub-agent, with agent_id and $ARGUMENTS as arguments to it. For tasks that can be done in parallel, and where dependencies are fulfilled, spawn sub-agents in parallel.
    c. Monitor sub-agent progress
    d. Keep an updated list of TODOs in $ARGUMENTS, including sub-agent status
-   e. When monitoring completes for all agent_ids, proceed to step 3
+   e. When monitoring completes for all agent_ids, proceed to step 4
 
-3. Report DONE to the orchestrating command
+4. Report DONE to the orchestrating command
 
 ## This part of the workflow is done when
 

--- a/.claude/commands/read-issue.md
+++ b/.claude/commands/read-issue.md
@@ -2,24 +2,26 @@
 
 ## Purpose
 
-Read Linear issue for the issue key listed in $ARGUMENTS and note all information in $ARGUMENTS.
+Read issue from the configured ticket system for the issue key listed in $ARGUMENTS and note all information in $ARGUMENTS.
 This command is called by an orchestrating command, and is one of the steps in a larger workflow.
 You MUST follow all workflow steps below, not skipping any step and doing all steps in order.
 
 ## Workflow Steps
 
-1. Read $ARGUMENTS and extract the Linear issue key
+1. Read $ARGUMENTS and extract the issue key
 
-2. Read Linear issue
+2. Get issue details - run the .claude/commands/ticket-get-issue.md command, passing the issue key as argument to it
 
-**Use Linear MCP to fetch issue details using Linear issue key**:
-- Get issue key, ID, title, and description
+The issue key is listed in $ARGUMENTS after `Issue Key:`
 
-**Linear lookup example**: `linear:get_issue` with query containing Linear issue key listed in $ARGUMENTS after `Linear Issue Key:`
+Format the argument as:
+```
+Ticket Number: [issue key from $ARGUMENTS]
+```
 
 3. Note findings in $ARGUMENTS
 
-Create a new section called `## Linear Issue Information`, with information on this format:
+Create a new section called `## Issue Information`, with information on this format:
 - **Key**: Issue key
 - **ID**: Issue ID
 - **Title**: Issue title

--- a/.claude/commands/review-pull-request.md
+++ b/.claude/commands/review-pull-request.md
@@ -21,6 +21,14 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 
 4. Repeat steps 1 through 3 until the user approves the pull request. You are not allowed to approve the pull request yourself.
 
-5. Add a comment to the Linear issue describing the user feedback and changes made as a response
+5. Add pull request feedback comment - run the .claude/commands/ticket-create-comment.md command, passing the issue key and feedback summary as arguments to it
+
+Get the issue key from the state management file in $ARGUMENTS.
+
+Format the arguments as:
+```
+Ticket Number: [issue key from state management file]
+Comment Text: [user feedback summary and changes made in response]
+```
 
 6. Report DONE to the orchestrating command

--- a/.claude/commands/specification-signoff.md
+++ b/.claude/commands/specification-signoff.md
@@ -23,6 +23,14 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 
 4. Iterate on the specification until the user gives their sign-off
 
-5. Add specification in Linear issue using `linear:create_comment`. The Linear issue information can be found in $ARGUMENTS
+5. Add specification comment - run the .claude/commands/ticket-create-comment.md command, passing the issue key and specification details as arguments to it
+
+Get the issue key from the state management file in $ARGUMENTS.
+
+Format the arguments as:
+```
+Ticket Number: [issue key from state management file]
+Comment Text: [specification details and assumptions]
+```
 
 6. Report DONE to the orchestrating command

--- a/.claude/commands/ticket-create-comment.md
+++ b/.claude/commands/ticket-create-comment.md
@@ -1,0 +1,47 @@
+# Ticket Create Comment Command
+
+## Purpose
+
+Add a comment to a ticket in the configured ticket system.
+This command is called by other orchestrating commands, and is one of the steps in a larger workflow.
+You MUST follow all workflow steps below, not skipping any step and doing all steps in order.
+
+## Arguments
+
+This command expects $ARGUMENTS in the following format:
+
+```
+Ticket Number: [ticket_key_or_id]
+Comment Text: [comment_content]
+```
+
+## Workflow Steps
+
+1. **Parse Arguments**: Extract the ticket number and comment text from $ARGUMENTS
+
+2. **Load Configuration**: Read `.claude/settings.claude-constructor.json` to determine the ticket provider
+
+3. **Execute Create Comment Operation**:
+
+### For Linear Provider (`"linear"`)
+- Use `linear:create_comment` with the ticket ID and comment text from $ARGUMENTS
+- Add the comment to the specified ticket
+
+4. **Output Results**: Display confirmation of the comment creation:
+   - **Ticket**: [ticket_number]
+   - **Comment Added**: [comment_preview - first 100 characters]
+   - **Result**: Success/Failure
+
+5. **Error Handling**: If the ticket operation fails, log the error but continue gracefully
+
+6. **Report DONE** to the orchestrating command
+
+## Usage Example
+
+From other commands, call this command with:
+
+```markdown
+run the .claude/commands/ticket_create_comment.md command, passing these arguments:
+Ticket Number: ABC-123
+Comment Text: Claude Code implementation started for specification_ABC-123_20240101.md
+```

--- a/.claude/commands/ticket-get-issue.md
+++ b/.claude/commands/ticket-get-issue.md
@@ -1,0 +1,46 @@
+# Ticket Get Issue Command
+
+## Purpose
+
+Retrieve issue details from the configured ticket system for a given ticket number.
+This command is called by other orchestrating commands, and is one of the steps in a larger workflow.
+You MUST follow all workflow steps below, not skipping any step and doing all steps in order.
+
+## Arguments
+
+This command expects $ARGUMENTS in the following format:
+
+```
+Ticket Number: [ticket_key_or_id]
+```
+
+## Workflow Steps
+
+1. **Parse Arguments**: Extract the ticket number from $ARGUMENTS
+
+2. **Load Configuration**: Read `.claude/settings.claude-constructor.json` to determine the ticket provider
+
+3. **Execute Get Issue Operation**:
+
+### For Linear Provider (`"linear"`)
+- Use `linear:get_issue` with the ticket number from $ARGUMENTS
+- Retrieve issue key, ID, title, and description
+
+4. **Output Results**: Display the issue information in this format:
+   - **Key**: Issue key
+   - **ID**: Issue ID  
+   - **Title**: Issue title
+   - **Description**: Issue description
+
+5. **Error Handling**: If the ticket operation fails, log the error but continue gracefully
+
+6. **Report DONE** to the orchestrating command
+
+## Usage Example
+
+From other commands, call this command with:
+
+```markdown
+run the .claude/commands/ticket_get_issue.md command, passing these arguments:
+Ticket Number: ABC-123
+```

--- a/.claude/commands/ticket-list-issue-statuses.md
+++ b/.claude/commands/ticket-list-issue-statuses.md
@@ -1,0 +1,48 @@
+# Ticket List Issue Statuses Command
+
+## Purpose
+
+List all available statuses for a ticket in the configured ticket system.
+This command is called by other orchestrating commands, and is one of the steps in a larger workflow.
+You MUST follow all workflow steps below, not skipping any step and doing all steps in order.
+
+## Arguments
+
+This command expects $ARGUMENTS in the following format:
+
+```
+Ticket Number: [ticket_key_or_id]
+```
+
+## Workflow Steps
+
+1. **Parse Arguments**: Extract the ticket number from $ARGUMENTS
+
+2. **Load Configuration**: Read `.claude/settings.claude-constructor.json` to determine the ticket provider
+
+3. **Execute List Statuses Operation**:
+
+### For Linear Provider (`"linear"`)
+- Use `linear:list_issue_statuses` with the ticket number from $ARGUMENTS
+- Retrieve all available status names for the ticket
+
+4. **Output Results**: Display the available statuses:
+   - **Ticket**: [ticket_number]
+   - **Available Statuses**: 
+     - [status_1]
+     - [status_2]  
+     - [status_3]
+     - ...
+
+5. **Error Handling**: If the ticket operation fails, log the error but return default workflow statuses
+
+6. **Report DONE** to the orchestrating command
+
+## Usage Example
+
+From other commands, call this command with:
+
+```markdown
+run the .claude/commands/ticket_list_issue_statuses.md command, passing these arguments:
+Ticket Number: ABC-123
+```

--- a/.claude/commands/ticket-update-issue.md
+++ b/.claude/commands/ticket-update-issue.md
@@ -1,0 +1,52 @@
+# Ticket Update Issue Command
+
+## Purpose
+
+Update the status of a ticket in the configured ticket system.
+This command is called by other orchestrating commands, and is one of the steps in a larger workflow.
+You MUST follow all workflow steps below, not skipping any step and doing all steps in order.
+
+## Arguments
+
+This command expects $ARGUMENTS in the following format:
+
+```
+Ticket Number: [ticket_key_or_id]
+New Status: [status_name]
+```
+
+Expected status values: "In Progress", "Code Review", "Ready For Human Review"
+
+## Workflow Steps
+
+1. **Parse Arguments**: Extract the ticket number and new status from $ARGUMENTS
+
+2. **Load Configuration**: Read `.claude/settings.claude-constructor.json` to determine the ticket provider
+
+3. **Execute Update Status Operation**:
+
+### For Linear Provider (`"linear"`)
+- First, use `linear:list_issue_statuses` to get all available statuses for the ticket
+- Find the best match for the new status from $ARGUMENTS (handles typos/variations)
+- Use `linear:update_issue` to set the ticket to the matched status
+- If no exact match is found, use the closest matching status name
+
+4. **Output Results**: Display confirmation of the status update:
+   - **Ticket**: [ticket_number]
+   - **Previous Status**: [if available]
+   - **New Status**: [updated_status]
+   - **Result**: Success/Failure
+
+5. **Error Handling**: If the ticket operation fails, log the error but continue gracefully
+
+6. **Report DONE** to the orchestrating command
+
+## Usage Example
+
+From other commands, call this command with:
+
+```markdown
+run the .claude/commands/ticket_update_issue.md command, passing these arguments:
+Ticket Number: ABC-123
+New Status: Code Review
+```

--- a/.claude/settings.claude-constructor.json
+++ b/.claude/settings.claude-constructor.json
@@ -1,0 +1,3 @@
+{
+  "provider": "linear"
+}

--- a/README.md
+++ b/README.md
@@ -57,11 +57,54 @@ Notes:
 
 ## Configuration
 
-This repository is a work in progress, and there are things you might want to change to fit your setup better.
-Such as:
+### Ticket System Integration
 
-- Using a different issue tracking system
-- Using different status transitions
+The workflow supports multiple ticket systems through an abstraction layer. This allows you to use Linear, Jira, GitHub Issues, or any other ticket system by configuring the provider.
+
+#### Configuration File
+
+Create or update `.claude/settings.claude-constructor.json` in your repository:
+
+```json
+{
+  "provider": "linear"
+}
+```
+
+#### Supported Providers
+
+**Linear (Default)**
+```json
+{
+  "provider": "linear"
+}
+```
+- Requires Linear MCP integration configured
+- Uses `linear:get_issue`, `linear:update_issue`, `linear:create_comment`, `linear:list_issue_statuses`
+- Supports fuzzy matching for status names
+
+#### Ticket System Requirements
+
+The workflow expects tickets to support these standard status transitions:
+- **"In Progress"** - When implementation begins
+- **"Code Review"** - During code review phase  
+- **"Ready For Human Review"** - When code review is approved
+
+Your ticket system should have statuses that match or can be mapped to these workflow states.
+
+#### Adding New Providers
+
+To add support for additional ticket systems (Jira, GitHub Issues, etc.):
+
+1. Update the ticket command files (`ticket-get-issue.md`, `ticket-update-issue.md`, etc.)
+2. Add provider-specific MCP command mappings
+3. Add the new provider option to the configuration
+
+### Other Customizations
+
+This repository is a work in progress, and there are things you might want to change to fit your setup better:
+
+- Using different status transitions within your ticket system
 - Adding reference points for your specific way of doing things, e.g. adding documentation on your E2E test principles in docs/ and then reference it in commands/write-end-to-end-tests.md
 - Tweaking your technical guardrails (described in `CLAUDE.md`). I recommend using pre-commit hooks and/or Claude Code hooks and/or CI to make sure the technical guardrails are enforced. TDD is also a great instrument in my opinion.
 - Adapting the git branch and commit guidelines to suit your preferences
@@ -108,7 +151,7 @@ I also recommend checking in on the work as it is happening, to gauge if anythin
 ## Prerequisites
 
 ### Technical Requirements
-- Linear MCP integration configured
+- Ticket system MCP integration configured (see Ticket System Integration section)
 - GitHub CLI (`gh`) authenticated
 - Git repository with `main` branch
 - Quality gate tools available
@@ -116,13 +159,14 @@ I also recommend checking in on the work as it is happening, to gauge if anythin
 ### Required Configuration Files
 - `/CLAUDE.md` - General principles, quality gates, and development workflow
 - `docs/commit.md` - Git commit guidelines
+- `.claude/settings.claude-constructor.json` - Ticket system provider configuration
 
 ### Optional Configuration Files
 - `docs/requirements.md` - Domain principles and business rules (can be referenced during implementation planning and code review)
 - ...and any additional context
 
 ### Issue Requirements
-**The workflow assumes well-groomed issues.** Users must ensure Linear issues contain:
+**The workflow assumes well-groomed issues.** Users must ensure ticket system issues contain:
 - Clear problem definition and business context
 - Detailed feature requirements and acceptance criteria
 - Proposed solution approach or architecture direction
@@ -136,20 +180,27 @@ The quality of the implementation depends directly on the quality of the issue d
 In this repository:
 
 ```
-.claude/commands/
-├── feature.md                      # Main orchestrator
-├── create-state-management-file.md
-├── read-issue.md
-├── define-implementation-plan.md
-├── write-specification.md
-├── specification-signoff.md
-├── git-checkout.md
-├── implement-increment.md
-├── implement-sub-increment.md
-├── write-end-to-end-tests.md
-├── code-review.md
-├── create-pull-request.md
-└── review-pull-request.md
+.claude/
+├── commands/
+│   ├── feature.md                      # Main orchestrator
+│   ├── create-state-management-file.md
+│   ├── read-issue.md
+│   ├── define-implementation-plan.md
+│   ├── write-specification.md
+│   ├── specification-signoff.md
+│   ├── git-checkout.md
+│   ├── implement-increment.md
+│   ├── implement-sub-increment.md
+│   ├── write-end-to-end-tests.md
+│   ├── code-review.md
+│   ├── create-pull-request.md
+│   ├── review-pull-request.md
+│   ├── ticket-get-issue.md             # Ticket system: Get issue details
+│   ├── ticket-update-issue.md          # Ticket system: Update status
+│   ├── ticket-create-comment.md        # Ticket system: Add comments
+│   ├── ticket-list-issue-statuses.md   # Ticket system: List statuses
+│   └── ticket-operations.md            # Ticket system abstraction (reference)
+└── settings.claude-constructor.json     # Ticket system configuration
 
 docs/
 └── git-commit.md


### PR DESCRIPTION
This PR abstracts the ticketing system commands. Right now Linear is still the only supported system but every linear command is now in a separate file. 

For example, instead running `linear:update_issue`, it will now run `.claude/commands/ticket-update-issue.md`, and so on.

The following commands/files have been added:

```
ticket-get-issue.md
ticket-update-issue.md
ticket-create-comment.md
ticket-list-issue-statuses.md
ticket-operations.md
```

The selected ticketing system is defined in a new file `.claude/settings.claude-constructor.json`. In the future, this file can contain more parameters for Claude Constructor.

**NOTE:** Please give it a good try before approving. I noticed that the tickets where not always updated 100%. Claude Code read the instructions just fine, left comments as expected, but it did not always move it to the next state.