### PR TITLE
feat: allow default branch to be more flexible

### DIFF
--- a/.claude/commands/create-pull-request.md
+++ b/.claude/commands/create-pull-request.md
@@ -17,10 +17,12 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 
 4. Push the commit using `git push`
 
-5. Create a pull request using `gh pr create --title "feat: [issue key] [brief description from commit]" --base main --head $(git branch --show-current)`
+5. Read the default branch name from the line "Default branch is [name]" in docs/git-commit.md
 
-6. Add a link to the pull request in the $ARGUMENTS in a new section called `## Pull Request`
+6. Create a pull request using `gh pr create --title "feat: [issue key] [brief description from commit]" --base [default branch name] --head $(git branch --show-current)`
 
-7. Update Linear issue status to "Code Review" using `linear:update_issue`
+7. Add a link to the pull request in the $ARGUMENTS in a new section called `## Pull Request`
 
-8. Report DONE to the orchestrating command
+8. Update Linear issue status to "Code Review" using `linear:update_issue`
+
+9.  Report DONE to the orchestrating command

--- a/.claude/commands/create-pull-request.md
+++ b/.claude/commands/create-pull-request.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Create pull request for the increment implemented to satisfy the issue described in $ARGUMENTS.
+Create pull request for increment implemented to satisfy the issue described in $ARGUMENTS.
 Add, commit, push code for the finished increment. Create Pull request in GitHub using the `gh` CLI.
 This command is called by an orchestrating command, and is one of the steps in a larger workflow.
 You MUST follow all workflow steps below, not skipping any step and doing all steps in order.
@@ -17,11 +17,11 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 
 4. Push the commit using `git push`
 
-5. Read the default branch name from the line "Default branch is [name]" in docs/git-commit.md
+5. Read the default branch name from the "default-branch" field in .claude/settings.claude-constructor.json
 
 6. Create a pull request using `gh pr create --title "feat: [issue key] [brief description from commit]" --base [default branch name] --head $(git branch --show-current)`
 
-7. Add a link to the pull request in the $ARGUMENTS in a new section called `## Pull Request`
+7. Add a link to the pull request in $ARGUMENTS in a new section called `## Pull Request`
 
 8. Update Linear issue status to "Code Review" using `linear:update_issue`
 

--- a/.claude/commands/git-checkout.md
+++ b/.claude/commands/git-checkout.md
@@ -8,7 +8,7 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 
 ## Workflow Steps
 
-1. Read the default branch name from the line "Default branch is [name]" in docs/git-commit.md, use with `git checkout [name]`.
+1. Read the default branch name from the "default-branch" field in .claude/settings.claude-constructor.json, use with `git checkout [name]`.
 
 2. Ensure that you have the latest changes, using `git pull`
 

--- a/.claude/commands/git-checkout.md
+++ b/.claude/commands/git-checkout.md
@@ -8,7 +8,7 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 
 ## Workflow Steps
 
-1. Ensure that you are on the main branch, using `git checkout main`
+1. Read the default branch name from the line "Default branch is [name]" in docs/git-commit.md, use with `git checkout [name]`.
 
 2. Ensure that you have the latest changes, using `git pull`
 

--- a/.claude/settings.claude-constructor.json
+++ b/.claude/settings.claude-constructor.json
@@ -1,3 +1,4 @@
 {
-  "issue-tracking-provider": "linear"
+  "issue-tracking-provider": "linear",
+  "default-branch": "main"
 }

--- a/README.md
+++ b/README.md
@@ -156,12 +156,12 @@ I also recommend checking in on the work as it is happening, to gauge if anythin
 ### Technical Requirements
 - Issue tracking system MCP integration configured (see Issue Tracking System Integration section)
 - GitHub CLI (`gh`) authenticated
-- Git repository with `main` branch
+- Git repository
 - Quality gate tools available
 
 ### Required Configuration Files
 - `/CLAUDE.md` - General principles, quality gates, and development workflow
-- `docs/git-commit.md` - Git commit guidelines
+- `docs/git-commit.md` - Git commit guidelines (example available in `docs/git-commit.md` in Claude Constructor)
 - `.claude/settings.claude-constructor.json` - Issue tracking system provider configuration
 
 ### Optional Configuration Files

--- a/docs/git-commit.md
+++ b/docs/git-commit.md
@@ -2,10 +2,6 @@
 
 ## Git Workflow
 
-### Default branch
-
-Default branch is `main`.
-
 ### Add Standards
 
 Never do `git add .`. Always add individual files, and only the files related to the current implementation you are working on.

--- a/docs/git-commit.md
+++ b/docs/git-commit.md
@@ -2,6 +2,10 @@
 
 ## Git Workflow
 
+### Default branch
+
+Default branch is `main`.
+
 ### Add Standards
 
 Never do `git add .`. Always add individual files, and only the files related to the current implementation you are working on.


### PR DESCRIPTION
I'm using this on a project where we haven't had the time to switch branch name so I wanted it to be more flexible.

### Breaking changes

Add these lines to `docs/git-commit.md` in repositories:

```markdown
### Default branch

Default branch is `main`.
```
