### PR TITLE
feat: add prompt mode only

### DIFF
--- a/.claude/commands/create-pull-request.md
+++ b/.claude/commands/create-pull-request.md
@@ -17,19 +17,17 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 
 4. Push the commit using `git push`
 
-5. Read the Settings section in $ARGUMENTS to get the following:
-   - The default branch name from the "default-branch" field
-   - The silent mode setting from the "silent-mode" field
+5. Read the Settings section in $ARGUMENTS
 
 6. **Check Silent Mode for Pull Request Creation**:
-   - If `silent-mode` is `false`:
+   - If `silent-mode` is `false` AND `issue-tracking-provider` is NOT `"prompt-issue"`:
      - Create a pull request using `gh pr create --title "feat: [issue key] [brief description from commit]" --base [default branch name] --head $(git branch --show-current)`
-   - If `silent-mode` is `true`:
+   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt-issue"`:
      - Log: "Silent mode: Would have created PR with title 'feat: [issue key] [brief description]'"
      - Skip the actual PR creation
 
 7. **Check Silent Mode for Issue Status Update**:
-   - If `silent-mode` is `false`:
+   - If `silent-mode` is `false` AND `issue-tracking-provider` is NOT `"prompt-issue"`:
      - Update issue status to "Code Review" - run the .claude/commands/issue/update-issue.md command, passing the issue key and new status as arguments to it
 
      Get the issue key from the state management file in $ARGUMENTS.
@@ -39,7 +37,7 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
      Issue Key: [issue key from state management file]
      New Status: Code Review
      ```
-   - If `silent-mode` is `true`:
+   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt-issue"`:
      - Log: "Silent mode: Would have updated issue [issue key] status to 'Code Review'"
      - Skip the issue update
 

--- a/.claude/commands/create-pull-request.md
+++ b/.claude/commands/create-pull-request.md
@@ -41,8 +41,4 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
      - Log: "Silent mode: Would have updated issue [issue key] status to 'Code Review'"
      - Skip the issue update
 
-8. **Legacy Linear Update** (if applicable and silent mode is false):
-   - Update Linear issue status to "Code Review" using `linear:update_issue`
-   - Skip if silent mode is true
-
-9. Report DONE to the orchestrating command
+8. Report DONE to the orchestrating command

--- a/.claude/commands/create-pull-request.md
+++ b/.claude/commands/create-pull-request.md
@@ -20,14 +20,14 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 5. Read the Settings section in $ARGUMENTS
 
 6. **Check Silent Mode for Pull Request Creation**:
-   - If `silent-mode` is `false` AND `issue-tracking-provider` is NOT `"prompt-issue"`:
+   - If `silent-mode` is `false` AND `issue-tracking-provider` is NOT `"prompt"`:
      - Create a pull request using `gh pr create --title "feat: [issue key] [brief description from commit]" --base [default branch name] --head $(git branch --show-current)`
-   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt-issue"`:
+   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt"`:
      - Log: "Silent mode: Would have created PR with title 'feat: [issue key] [brief description]'"
      - Skip the actual PR creation
 
 7. **Check Silent Mode for Issue Status Update**:
-   - If `silent-mode` is `false` AND `issue-tracking-provider` is NOT `"prompt-issue"`:
+   - If `silent-mode` is `false` AND `issue-tracking-provider` is NOT `"prompt"`:
      - Update issue status to "Code Review" - run the .claude/commands/issue/update-issue.md command, passing the issue key and new status as arguments to it
 
      Get the issue key from the state management file in $ARGUMENTS.
@@ -37,7 +37,7 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
      Issue Key: [issue key from state management file]
      New Status: Code Review
      ```
-   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt-issue"`:
+   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt"`:
      - Log: "Silent mode: Would have updated issue [issue key] status to 'Code Review'"
      - Skip the issue update
 

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -22,7 +22,7 @@ Create a TODO list for the workflow steps, and follow it.
 ## Pre-Processing
 
 Before starting the workflow for user prompts, create an issue key based on $ARGUMENTS:
-- List the contents of `state_management`
+- List the contents of `state_management` in the additional directories
 - If there are no filenames using the format `prompt-{number}`, use issue key `prompt-1`
 - If there is at least one filename using the format `prompt-{number}`, use issue key `prompt-{number+1}`
 

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -1,7 +1,7 @@
 ---
-argument-hint: [issue key]
-description: Implement feature described in [issue key]
-allowed-tools: Bash(python3 ./scripts/load_settings.py)
+argument-hint: [issue key or user prompt]
+description: Implement feature from issue tracking system or user prompt
+allowed-tools: Bash(python3 scripts/load_settings.py)
 ---
 
 # Feature Implementation Command
@@ -14,10 +14,23 @@ You are responsible for making sure all steps are done according to the workflow
 All steps MUST complete, and they must be completed in the order described below.
 You are only allowed to move to the next step after the previous step has reported DONE.
 
-The issue key for the feature to implement is in $ARGUMENTS.
+The issue key or prompt for the feature to implement is in $ARGUMENTS.
 
 IMPORTANT: The workflow steps will report to you when they're done, and only then can the next step start. Do not stop until the workflow is completed.
 Create a TODO list for the workflow steps, and follow it.
+
+## Pre-Processing
+
+Before starting the workflow, slugify the issue key/feature name from $ARGUMENTS:
+- Convert to lowercase
+- Replace spaces with hyphens
+- Remove special characters except hyphens and underscores
+- Remove consecutive hyphens
+- Example: "Add Dark Mode" → "add-dark-mode"
+- Example: "Fix login bug!" → "fix-login-bug"
+- Example: "ABC-123" → "ABC-123"
+
+Use this slugified version as the issue key for ALL subsequent workflow steps.
 
 ## Workflow Steps
 

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -1,5 +1,5 @@
 ---
-argument-hint: [issue key or user prompt]
+argument-hint: [issue key or prompt]
 description: Implement feature from issue tracking system or user prompt
 allowed-tools: Bash(python3 scripts/load_settings.py)
 ---
@@ -21,16 +21,10 @@ Create a TODO list for the workflow steps, and follow it.
 
 ## Pre-Processing
 
-Before starting the workflow, slugify the issue key/feature name from $ARGUMENTS:
-- Convert to lowercase
-- Replace spaces with hyphens
-- Remove special characters except hyphens and underscores
-- Remove consecutive hyphens
-- Example: "Add Dark Mode" → "add-dark-mode"
-- Example: "Fix login bug!" → "fix-login-bug"
-- Example: "ABC-123" → "ABC-123"
-
-Use this slugified version as the issue key for ALL subsequent workflow steps.
+Before starting the workflow for user prompts, create an issue key based on $ARGUMENTS:
+- List the contents of `state_management`
+- If there are no filenames using the format `prompt-{number}`, use issue key `prompt-1`
+- If there is at least one filename using the format `prompt-{number}`, use issue key `prompt-{number+1}`
 
 ## Workflow Steps
 

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: [issue key or prompt]
 description: Implement feature from issue tracking system or user prompt
-allowed-tools: Bash(python3 scripts/load_settings.py)
+allowed-tools: Bash(python3 ./scripts/load_settings.py)
 ---
 
 # Feature Implementation Command

--- a/.claude/commands/issue/create-comment.md
+++ b/.claude/commands/issue/create-comment.md
@@ -22,7 +22,7 @@ Comment Text: [comment_content]
 2. **Load Settings**: Read the Settings section in $ARGUMENTS
 
 3. **Check Silent Mode or Prompt Issue Provider**: 
-   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt-issue"`:
+   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt"`:
      - Log the comment operation locally: "Silent mode: Would have added comment to [issue_key]: [comment_preview]"
      - Skip the actual API call (step 4)
      - Continue to step 5

--- a/.claude/commands/issue/create-comment.md
+++ b/.claude/commands/issue/create-comment.md
@@ -19,10 +19,10 @@ Comment Text: [comment_content]
 
 1. **Parse Arguments**: Extract the issue key and comment text from $ARGUMENTS
 
-2. **Load Settings**: Read the Settings section in $ARGUMENTS to get the silent mode setting
+2. **Load Settings**: Read the Settings section in $ARGUMENTS
 
-3. **Check Silent Mode**: 
-   - If `silent-mode` is `true` in the configuration:
+3. **Check Silent Mode or Prompt Issue Provider**: 
+   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt-issue"`:
      - Log the comment operation locally: "Silent mode: Would have added comment to [issue_key]: [comment_preview]"
      - Skip the actual API call (step 4)
      - Continue to step 5

--- a/.claude/commands/issue/get-issue.md
+++ b/.claude/commands/issue/get-issue.md
@@ -22,14 +22,6 @@ Issue Key: [issue_key]
 
 3. **Execute Get Issue Operation**:
 
-### For Prompt Issue Provider (`"prompt-issue"`)
-- Prompt the user: "Please provide the following details for your feature/task:"
-- Ask for:
-  - **Title**: What feature or task are you implementing?
-  - **Description**: Provide detailed description of requirements, acceptance criteria, and any technical constraints
-- Use the provided issue key from $ARGUMENTS as both key and ID
-- Continue to step 4 with the user-provided information
-
 ### For Linear Provider (`"linear"`)
 - Use `linear:get_issue` with the issue key from $ARGUMENTS
 - Retrieve issue key, ID, title, and description
@@ -39,6 +31,10 @@ Issue Key: [issue_key]
 - Retrieve issue key, ID, title, and description
 
 4. **Output Results**: Display the issue information in this format:
+   ### For Prompt Issue Provider (`"prompt-issue"`)
+   - **Prompt**: User prompt
+
+   ### For Issue Tracking Providers
    - **Key**: Issue key
    - **ID**: Issue ID
    - **Title**: Issue title

--- a/.claude/commands/issue/get-issue.md
+++ b/.claude/commands/issue/get-issue.md
@@ -22,6 +22,14 @@ Issue Key: [issue_key]
 
 3. **Execute Get Issue Operation**:
 
+### For Prompt Issue Provider (`"prompt-issue"`)
+- Prompt the user: "Please provide the following details for your feature/task:"
+- Ask for:
+  - **Title**: What feature or task are you implementing?
+  - **Description**: Provide detailed description of requirements, acceptance criteria, and any technical constraints
+- Use the provided issue key from $ARGUMENTS as both key and ID
+- Continue to step 4 with the user-provided information
+
 ### For Linear Provider (`"linear"`)
 - Use `linear:get_issue` with the issue key from $ARGUMENTS
 - Retrieve issue key, ID, title, and description

--- a/.claude/commands/issue/get-issue.md
+++ b/.claude/commands/issue/get-issue.md
@@ -31,7 +31,7 @@ Issue Key: [issue_key]
 - Retrieve issue key, ID, title, and description
 
 4. **Output Results**: Display the issue information in this format:
-   ### For Prompt Issue Provider (`"prompt-issue"`)
+   ### For Prompt Issue Provider (`"prompt"`)
    - **Prompt**: User prompt
 
    ### For Issue Tracking Providers

--- a/.claude/commands/issue/update-issue.md
+++ b/.claude/commands/issue/update-issue.md
@@ -24,7 +24,7 @@ Expected status values: "In Progress", "Code Review"
 2. **Load Settings**: Read the Settings section in $ARGUMENTS
 
 3. **Check Silent Mode or Prompt Issue Provider**:
-   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt-issue"`:
+   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt"`:
      - Log the status update operation locally: "Silent mode: Would have updated [issue_key] status to '[new_status]'"
      - Skip the actual API calls (step 4)
      - Continue to step 5

--- a/.claude/commands/issue/update-issue.md
+++ b/.claude/commands/issue/update-issue.md
@@ -21,10 +21,10 @@ Expected status values: "In Progress", "Code Review"
 
 1. **Parse Arguments**: Extract the issue key and new status from $ARGUMENTS
 
-2. **Load Settings**: Read the Settings section in $ARGUMENTS to get the silent mode setting
+2. **Load Settings**: Read the Settings section in $ARGUMENTS
 
-3. **Check Silent Mode**:
-   - If `silent-mode` is `true` in the configuration:
+3. **Check Silent Mode or Prompt Issue Provider**:
+   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt-issue"`:
      - Log the status update operation locally: "Silent mode: Would have updated [issue_key] status to '[new_status]'"
      - Skip the actual API calls (step 4)
      - Continue to step 5

--- a/.claude/commands/review-pull-request.md
+++ b/.claude/commands/review-pull-request.md
@@ -11,10 +11,10 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 1. **Load Settings**: Read the Settings section in $ARGUMENTS
 
 2. **Check Silent Mode**:
-   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt-issue"`:
+   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt"`:
      - Log: "Silent mode: Skipping PR review monitoring and comments"
      - Skip to step 7
-   - If `silent-mode` is `false` AND `issue-tracking-provider` is NOT `"prompt-issue"`:
+   - If `silent-mode` is `false` AND `issue-tracking-provider` is NOT `"prompt"`:
      - Continue with normal PR review workflow (steps 3-6)
 
 3. Monitor the pull request for comments and/or reviews. Use `gh api repos/{OWNER}/{REPO}/pulls/{PR_NUMBER}/comments --jq '.[] | {author: .user.login, body: .body, path: .path, line: .line}'`
@@ -29,8 +29,8 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 
 6. Repeat steps 3 through 5 until the user approves the pull request. You are not allowed to approve the pull request yourself.
 
-7. **Add pull request feedback comment** (only if silent mode and not prompt-issue):
-   - If `silent-mode` is `false` AND `issue-tracking-provider` is NOT `"prompt-issue"`:
+7. **Add pull request feedback comment** (only if silent mode and not prompt):
+   - If `silent-mode` is `false` AND `issue-tracking-provider` is NOT `"prompt"`:
      - Run the .claude/commands/issue/create-comment.md command, passing the issue key and feedback summary as arguments to it
 
      Get the issue key from the state management file in $ARGUMENTS.
@@ -40,7 +40,7 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
      Issue Key: [issue key from state management file]
      Comment Text: [user feedback summary and changes made in response]
      ```
-   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt-issue"`:
+   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt"`:
      - Log: "Silent mode: Would have added PR feedback comment to issue"
 
 8. Report DONE to the orchestrating command

--- a/.claude/commands/review-pull-request.md
+++ b/.claude/commands/review-pull-request.md
@@ -8,13 +8,13 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 
 ## Workflow Steps
 
-1. **Load Settings**: Read the Settings section in $ARGUMENTS to get the silent-mode setting
+1. **Load Settings**: Read the Settings section in $ARGUMENTS
 
 2. **Check Silent Mode**:
-   - If `silent-mode` is `true`:
+   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt-issue"`:
      - Log: "Silent mode: Skipping PR review monitoring and comments"
      - Skip to step 7
-   - If `silent-mode` is `false`:
+   - If `silent-mode` is `false` AND `issue-tracking-provider` is NOT `"prompt-issue"`:
      - Continue with normal PR review workflow (steps 3-6)
 
 3. Monitor the pull request for comments and/or reviews. Use `gh api repos/{OWNER}/{REPO}/pulls/{PR_NUMBER}/comments --jq '.[] | {author: .user.login, body: .body, path: .path, line: .line}'`
@@ -29,8 +29,8 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 
 6. Repeat steps 3 through 5 until the user approves the pull request. You are not allowed to approve the pull request yourself.
 
-7. **Add pull request feedback comment** (only if silent mode is false):
-   - If `silent-mode` is `false`:
+7. **Add pull request feedback comment** (only if silent mode and not prompt-issue):
+   - If `silent-mode` is `false` AND `issue-tracking-provider` is NOT `"prompt-issue"`:
      - Run the .claude/commands/issue/create-comment.md command, passing the issue key and feedback summary as arguments to it
 
      Get the issue key from the state management file in $ARGUMENTS.
@@ -40,7 +40,7 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
      Issue Key: [issue key from state management file]
      Comment Text: [user feedback summary and changes made in response]
      ```
-   - If `silent-mode` is `true`:
+   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt-issue"`:
      - Log: "Silent mode: Would have added PR feedback comment to issue"
 
 8. Report DONE to the orchestrating command

--- a/.claude/settings.claude-constructor.schema.json
+++ b/.claude/settings.claude-constructor.schema.json
@@ -11,9 +11,9 @@
     },
     "issue-tracking-provider": {
       "type": "string",
-      "description": "The issue tracking system to use for fetching issues and updating statuses. Default: 'linear'",
-      "enum": ["linear", "jira"],
-      "default": "linear"
+      "description": "The issue tracking system to use for fetching issues and updating statuses. Default: 'prompt'",
+      "enum": ["linear", "jira", "prompt"],
+      "default": "prompt"
     },
     "default-branch": {
       "type": "string",

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ An example configuration is provided in `.claude/settings.claude-constructor.exa
 ```json
 # .claude/settings.claude-constructor.json
 {
-  "issue-tracking-provider": "prompt-issue"
+  "issue-tracking-provider": "prompt"
 }
 ```
 - No external issue tracking system required
@@ -140,7 +140,7 @@ When silent mode is enabled:
 - **PR review comments**: Skipped entirely
 - All other operations (git commits, code changes, tests) execute normally
 
-**Note**: The `"prompt-issue"` provider automatically behaves like silent mode, so you don't need to set both.
+**Note**: The `"prompt"` provider automatically behaves like silent mode, so you don't need to set both.
 
 #### Issue Tracking System Requirements
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A systematic workflow engine for implementing functionality with Claude Code, de
 
 ## Overview
 
-This system orchestrates feature development through a structured 13-step workflow that covers complete implementation, comprehensive testing, and automated code review. Each command works together as part of a larger orchestrated process.
+This system orchestrates feature development through a structured 14-step workflow that covers complete implementation, comprehensive testing, and automated code review. Each command works together as part of a larger orchestrated process.
 The goal has been to enable Claude Code to work for extended periods of time without deviating from the plan.
 
 ## Core Workflow
@@ -14,21 +14,22 @@ The main orchestrator (`feature.md`) follows this sequence:
 ### Planning
 1. **Read configuration files** - Load development guidelines, quality gates, and other documentation
 2. **Create state management file** - Used to track workflow progress
-3. **Read Linear issue** - Fetch issue details via Linear MCP
-4. **Define requirements** - Create detailed requirements specification covering business value, user journey, acceptance criteria, and technical constraints
-5. **Get requirements sign-off** - Iterate on the requirements definition until it's ready *(Human Required)*
-6. **Write specification** - Technical spec with parallelization plan
-7. **Get specification sign-off** - Iterate on the specification until it's ready *(Human Required)*
+3. **Read settings** - Get issue tracker and other settings
+4. **Read Linear issue** - Fetch issue details via Linear MCP
+5. **Define requirements** - Create detailed requirements specification covering business value, user journey, acceptance criteria, and technical constraints
+6. **Get requirements sign-off** - Iterate on the requirements definition until it's ready *(Human Required)*
+7. **Write specification** - Technical spec with parallelization plan
+8. **Get specification sign-off** - Iterate on the specification until it's ready *(Human Required)*
 
 ### Implementation
-8. **Check out new branch** - Create feature branch
-9. **Implement increment** - Execute with parallel subagents if possible
-10. **Write end-to-end tests** - Cover user behavior
+9. **Check out new branch** - Create feature branch
+10. **Implement increment** - Execute with parallel subagents if possible
+11. **Write end-to-end tests** - Cover user behavior
 
 ### Review
-11. **Perform code review** - Self-review, addressing findings automatically
-12. **Create pull request** - Creating a pull request on GitHub, describing the work
-13. **Review pull request** - Monitor and respond to feedback *(Human Required)*
+12. **Perform code review** - Self-review, addressing findings automatically
+13. **Create pull request** - Creating a pull request on GitHub, describing the work
+14. **Review pull request** - Monitor and respond to feedback *(Human Required)*
 
 ## Usage
 
@@ -104,6 +105,18 @@ An example configuration is provided in `.claude/settings.claude-constructor.exa
 - Uses `jira:get_issue`, `jira:add_comment_to_issue`, `jira:get_transitions_for_issue`, `jira:transition_issue`
 - Supports fuzzy matching for status names
 
+**Prompt Issue (No External Integration)**
+```json
+# .claude/settings.claude-constructor.json
+{
+  "issue-tracking-provider": "prompt-issue"
+}
+```
+- No external issue tracking system required
+- Prompts user for issue title and description during workflow
+- Automatically skips all external API calls (same as silent mode)
+- Perfect for local development and experimentation
+
 #### Silent Mode
 
 Silent mode allows you to run the workflow without making external API calls to issue tracking systems or creating GitHub pull requests. This is useful for:
@@ -126,6 +139,8 @@ When silent mode is enabled:
 - **GitHub pull requests**: Code is committed and pushed, but PR creation is skipped
 - **PR review comments**: Skipped entirely
 - All other operations (git commits, code changes, tests) execute normally
+
+**Note**: The `"prompt-issue"` provider automatically behaves like silent mode, so you don't need to set both.
 
 #### Issue Tracking System Requirements
 


### PR DESCRIPTION
Similar to silent mode, but this takes the input from the prompt instead of a issue tracking provider.