### PR TITLE
fix: separate PR operations from issue tracking in prompt mode

### DIFF
--- a/.claude/commands/create-pull-request.md
+++ b/.claude/commands/create-pull-request.md
@@ -20,9 +20,9 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 5. Read the Settings section in $ARGUMENTS
 
 6. **Check Silent Mode for Pull Request Creation**:
-   - If `silent-mode` is `false` AND `issue-tracking-provider` is NOT `"prompt"`:
+   - If `silent-mode` is `false`:
      - Create a pull request using `gh pr create --title "feat: [issue key] [brief description from commit]" --base [default branch name] --head $(git branch --show-current)`
-   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt"`:
+   - If `silent-mode` is `true`:
      - Log: "Silent mode: Would have created PR with title 'feat: [issue key] [brief description]'"
      - Skip the actual PR creation
 

--- a/.claude/commands/review-pull-request.md
+++ b/.claude/commands/review-pull-request.md
@@ -11,10 +11,10 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 1. **Load Settings**: Read the Settings section in $ARGUMENTS
 
 2. **Check Silent Mode**:
-   - If `silent-mode` is `true` OR `issue-tracking-provider` is `"prompt"`:
+   - If `silent-mode` is `true`:
      - Log: "Silent mode: Skipping PR review monitoring and comments"
      - Skip to step 7
-   - If `silent-mode` is `false` AND `issue-tracking-provider` is NOT `"prompt"`:
+   - If `silent-mode` is `false`:
      - Continue with normal PR review workflow (steps 3-6)
 
 3. Monitor the pull request for comments and/or reviews. Use `gh api repos/{OWNER}/{REPO}/pulls/{PR_NUMBER}/comments --jq '.[] | {author: .user.login, body: .body, path: .path, line: .line}'`


### PR DESCRIPTION
## Summary
- Fixed bug where PR operations were incorrectly skipped when using prompt mode with silent-mode disabled
- Separated PR creation/review logic (controlled by silent-mode only) from issue tracking operations (controlled by both silent-mode and issue-tracking-provider)
- PR operations now work correctly with prompt mode when silent-mode is false

## Changes
- Updated `.claude/commands/create-pull-request.md`: PR creation now only checks silent-mode flag
- Updated `.claude/commands/review-pull-request.md`: PR review monitoring now only checks silent-mode flag
- Issue tracking operations remain conditional on both flags as intended

## Test plan
- [ ] Test with prompt mode + silent-mode=false: PR should be created, issue tracking skipped
- [ ] Test with prompt mode + silent-mode=true: Both PR and issue tracking should be skipped  
- [ ] Test with non-prompt mode + silent-mode=false: Both PR and issue tracking should work
- [ ] Test with non-prompt mode + silent-mode=true: Both PR and issue tracking should be skipped

🤖 Generated with [Claude Code](https://claude.ai/code)