### PR TITLE
Fix: Add cross-platform Python command compatibility

### DIFF
--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: [issue key or prompt]
 description: Implement feature from issue tracking system or user prompt
-allowed-tools: Bash(python3 ./scripts/load_settings.py)
+allowed-tools: Bash($(command -v python3 || command -v python) ./scripts/load_settings.py)
 ---
 
 # Feature Implementation Command

--- a/.claude/commands/read-settings.md
+++ b/.claude/commands/read-settings.md
@@ -9,7 +9,7 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 
 ## Workflow Steps
 
-1. Read settings by running `python3 ./scripts/load_settings.py`.
+1. Read settings by running `$(command -v python3 || command -v python) ./scripts/load_settings.py`.
 
 2. Add the settings to the state management file (path in $ARGUMENTS), in a new section called `## Settings`, on this format
     - key: value

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ./scripts/check_path.py"
+            "command": "$(command -v python3 || command -v python) ./scripts/check_path.py"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Replace hardcoded `python3` commands with portable fallback pattern
- Ensures compatibility across different Python installations
- No setup required for end users

## Problem
Some systems have Python 3 installed as `python` instead of `python3`, causing command failures. This particularly affects:
- Windows systems with Python installed via python.org
- WSL environments  
- Systems without python-is-python3 package

## Solution
Use `$(command -v python3 || command -v python)` pattern that:
1. First tries to find `python3` command
2. Falls back to `python` if `python3` not found
3. Works seamlessly on all POSIX systems

## Changes
- `.claude/commands/read-settings.md`: Updated Python command in workflow step
- `.claude/commands/feature.md`: Updated allowed-tools directive
- `.claude/settings.json`: Updated hook command for path checking

## Testing
Verified the command works correctly:
```bash
$ $(command -v python3 || command -v python) ./scripts/load_settings.py
Using LOCAL settings with SCHEMA defaults for missing values:
issue-tracking-provider: jira
default-branch: main
silent-mode: False
```

## Impact
- ✅ No breaking changes
- ✅ Backwards compatible
- ✅ No user action required
- ✅ Works on more systems out of the box

🤖 Generated with [Claude Code](https://claude.ai/code)