### PR TITLE
refactor(workflow): delegate spec updates to subagents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "claude-constructor",
       "source": "./plugins/claude-constructor",
       "description": "A workflow automation system that helps Claude Code implement features systematically with built-in planning, validation, and review steps",
-      "version": "1.2.0"
+      "version": "1.3.0"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-constructor",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-constructor",
-      "version": "1.0.0",
+      "version": "1.3.0",
       "devDependencies": {
         "husky": "^9.1.7",
         "markdownlint-cli2": "^0.17.1"
@@ -502,6 +502,7 @@
       "integrity": "sha512-XH06ZOi8wCrtOSSj3p8y3yJzwgzYOSa7lglNyS3fP05JPRzRGyjauBb5UvlLUSCGysMmULS1moxdRHHudV+g/Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "globby": "14.0.2",
         "js-yaml": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-constructor",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A workflow automation plugin for Claude Code",
   "private": true,
   "scripts": {

--- a/plugins/claude-constructor/.claude-plugin/plugin.json
+++ b/plugins/claude-constructor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-constructor",
   "description": "A workflow automation system that helps Claude Code implement features systematically with built-in planning, validation, and review steps",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "Jonas Martinsson & Anders Hassis",
     "url": "https://github.com/Hurblat/claude-constructor/graphs/contributors"

--- a/plugins/claude-constructor/agents/requirements-definer.md
+++ b/plugins/claude-constructor/agents/requirements-definer.md
@@ -20,6 +20,8 @@ Your role is to create a Requirements Definition that will later be used to crea
 When defining requirements, you will:
 
 1. **Parse Input**:
+   - Check if prompt contains "Resolved questions:"
+   - If yes → **QUESTION_RESOLUTION MODE** (skip to step 11)
    - Check if prompt contains "User feedback to address:"
    - If yes → Extract the state management file path and user feedback separately
    - If no → prompt contains only the state management file path
@@ -141,6 +143,39 @@ When defining requirements, you will:
 
 - Update the state management file with the path to the created specification file, in a section called `## Specification File`
 - Ensure the specification file path is accessible for subsequent workflow steps
+
+11. **Handle Question Resolution Mode** (only if "Resolved questions:" detected in step 1):
+
+    When prompt contains resolved questions in this format:
+
+    ```text
+    State management file: [path]
+    Resolved questions:
+    - [Question title]: [Selected option with description]
+    - [Question title]: [Selected option with description]
+    ```
+
+    Execute these steps:
+
+    a. **Read state management file** from the path provided
+    b. **Locate and read specification file** from state management
+    c. **Parse resolved questions** from the prompt (each line after "Resolved questions:")
+    d. **Update specification file**:
+       - Find the `### Open Questions` section in Requirements Definition
+       - For each resolved question:
+         - Locate the question by its title (ignoring `[STRUCTURED]` tag)
+         - Remove the entire question block from Open Questions
+       - Create or append to `### Resolved Questions` section
+       - For each resolved question, add:
+
+         ```markdown
+         #### [Question title]
+
+         **Answer:** [Selected option with description]
+         ```
+
+       - If Open Questions section becomes empty, remove it entirely
+    e. **Exit** - do not proceed to other steps
 
 ## Output Format
 

--- a/plugins/claude-constructor/agents/specification-writer.md
+++ b/plugins/claude-constructor/agents/specification-writer.md
@@ -20,6 +20,8 @@ Your role is to take these requirements and create a detailed implementation pla
 When writing a specification, you will:
 
 1. **Parse Input**:
+   - Check if prompt contains "Resolved questions:"
+   - If yes → **QUESTION_RESOLUTION MODE** (skip to step 11)
    - Check if prompt contains "User feedback to address:"
    - If yes → Extract the state management file path and user feedback separately
    - If no → prompt contains only the state management file path
@@ -139,6 +141,39 @@ When writing a specification, you will:
 - Have you addressed all aspects mentioned in the original issue?
 - Is the scope clearly bounded to prevent scope creep?
 - If in revision mode, have you addressed all user feedback?
+
+11. **Handle Question Resolution Mode** (only if "Resolved questions:" detected in step 1):
+
+    When prompt contains resolved questions in this format:
+
+    ```text
+    State management file: [path]
+    Resolved questions:
+    - [Question title]: [Selected option with description]
+    - [Question title]: [Selected option with description]
+    ```
+
+    Execute these steps:
+
+    a. **Read state management file** from the path provided
+    b. **Locate and read specification file** from state management
+    c. **Parse resolved questions** from the prompt (each line after "Resolved questions:")
+    d. **Update specification file**:
+       - Find the `### Technical Questions` section in Implementation Plan
+       - For each resolved question:
+         - Locate the question by its title (ignoring `[STRUCTURED]` tag)
+         - Remove the entire question block from Technical Questions
+       - Create or append to `### Resolved Technical Questions` section
+       - For each resolved question, add:
+
+         ```markdown
+         #### [Question title]
+
+         **Answer:** [Selected option with description]
+         ```
+
+       - If Technical Questions section becomes empty, remove it entirely
+    e. **Exit** - do not proceed to other steps
 
 ### Output Format
 

--- a/plugins/claude-constructor/commands/requirements-sign-off.md
+++ b/plugins/claude-constructor/commands/requirements-sign-off.md
@@ -59,10 +59,16 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
              - options: Array with label and description for each option
           3. Await and collect user responses for all questions in batch
           4. Continue to next batch
-     c. After all batches complete, update specification file:
-        - Move all answered questions to `### Resolved Questions` section (create if needed)
-        - Format: Question title + "**Answer:** [selected option with description]"
-        - Remove the `[STRUCTURED]` tag from resolved questions
+     c. After all batches complete, use requirements-definer subagent to update specification:
+
+        ```text
+        State management file: $1
+        Resolved questions:
+        - [Question title]: [Selected option with description]
+        - [Question title]: [Selected option with description]
+        ```
+
+        The subagent will move answered questions to `### Resolved Questions` section
 
 4. **Handle Open-Ended Questions**:
    - If only OPEN-ENDED questions remain:
@@ -73,9 +79,17 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
    - Present the Requirements Definition section to the user for review
    - Tell the user where to find the full specification: "You can review the full specification at: `{specification-file-path}`"
 
-6. **Get User Feedback**:
-   - Ask the user to read and provide feedback on the Requirements Definition
-   - If user has feedback:
+6. **Get User Approval**:
+   - Use AskUserQuestion tool with:
+     - question: "Do you approve these requirements?"
+     - header: "Requirements"
+     - options:
+       - label: "Approve"
+         description: "Requirements are complete and accurate, proceed to implementation planning"
+       - label: "Request changes"
+         description: "I have feedback to provide"
+   - If user selects "Approve": proceed to step 7
+   - If user selects "Request changes" or provides feedback via "Other":
      a. Use the requirements-definer subagent to revise requirements:
 
         ```text
@@ -85,7 +99,6 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 
      b. The subagent will detect the feedback and revise accordingly
      c. Return to step 1 for re-review
-   - If user provides explicit sign-off, proceed to step 7
 
 7. **Update Workflow Progress**:
    - Read the state management file ($1)

--- a/plugins/claude-constructor/commands/specification-sign-off.md
+++ b/plugins/claude-constructor/commands/specification-sign-off.md
@@ -59,10 +59,16 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
              - options: Array with label and description for each option
           3. Await and collect user responses for all questions in batch
           4. Continue to next batch
-     c. After all batches complete, update specification file:
-        - Move all answered questions to `### Resolved Technical Questions` section (create if needed)
-        - Format: Question title + "**Answer:** [selected option with description]"
-        - Remove the `[STRUCTURED]` tag from resolved questions
+     c. After all batches complete, use specification-writer subagent to update specification:
+
+        ```text
+        State management file: $1
+        Resolved questions:
+        - [Question title]: [Selected option with description]
+        - [Question title]: [Selected option with description]
+        ```
+
+        The subagent will move answered questions to `### Resolved Technical Questions` section
 
 4. **Handle Open-Ended Questions**:
    - If only OPEN-ENDED questions remain:
@@ -73,9 +79,17 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
    - Present the Implementation Plan section to the user for review
    - Tell the user where to find the full specification: "You can review the full specification at: `{specification-file-path}`"
 
-6. **Get User Feedback**:
-   - Ask the user to read and provide feedback on the Implementation Plan
-   - If user has feedback:
+6. **Get User Approval**:
+   - Use AskUserQuestion tool with:
+     - question: "Do you approve this implementation plan?"
+     - header: "Specification"
+     - options:
+       - label: "Approve"
+         description: "Implementation plan is complete and accurate, proceed to implementation"
+       - label: "Request changes"
+         description: "I have feedback to provide"
+   - If user selects "Approve": proceed to step 7
+   - If user selects "Request changes" or provides feedback via "Other":
      a. Use the specification-writer subagent to revise specification:
 
         ```text
@@ -85,7 +99,6 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
 
      b. The subagent will detect the feedback and revise accordingly
      c. Return to step 1 for re-review
-   - If user provides explicit sign-off, proceed to step 7
 
 7. **Update Workflow Progress**:
    - Read the state management file ($1)


### PR DESCRIPTION
## Summary

- Delegate question resolution from sign-off commands to their respective subagents (requirements-definer, specification-writer)
- Add "Question Resolution Mode" to both agents for handling resolved questions
- Improve approval flow with structured AskUserQuestion options (Approve/Request changes)
- Bump version to 1.3.0

## Test plan

- [ ] Run `/feature prompt-test` workflow through requirements sign-off
- [ ] Verify structured questions are resolved and moved to Resolved Questions section
- [ ] Verify approval flow presents Approve/Request changes options
- [ ] Run through specification sign-off and verify same behavior

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving questions within requirements and specification workflows.
  * Enhanced approval process with explicit decision options (Approve/Request Changes) for better workflow control.

* **Chores**
  * Bumped version to 1.3.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->