### PR TITLE
fix(workflow): prevent specification sign-off from getting stuck

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "claude-constructor",
       "source": "./plugins/claude-constructor",
       "description": "A workflow automation system that helps Claude Code implement features systematically with built-in planning, validation, and review steps",
-      "version": "1.3.0"
+      "version": "1.3.1"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-constructor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-constructor",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "devDependencies": {
         "husky": "^9.1.7",
         "markdownlint-cli2": "^0.17.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-constructor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A workflow automation plugin for Claude Code",
   "private": true,
   "scripts": {

--- a/plugins/claude-constructor/.claude-plugin/plugin.json
+++ b/plugins/claude-constructor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-constructor",
   "description": "A workflow automation system that helps Claude Code implement features systematically with built-in planning, validation, and review steps",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "Jonas Martinsson & Anders Hassis",
     "url": "https://github.com/Hurblat/claude-constructor/graphs/contributors"

--- a/plugins/claude-constructor/commands/specification-sign-off.md
+++ b/plugins/claude-constructor/commands/specification-sign-off.md
@@ -104,6 +104,8 @@ You MUST follow all workflow steps below, not skipping any step and doing all st
    - Read the state management file ($1)
    - Update `specificationApproved: false` to `specificationApproved: true` in the Workflow Progress section
 
-8. **Add Issue Comment**:
-   - Read the state management file to get the issue key
-   - Use the Skill tool to execute `/create-comment [issue-key] "[specification details and assumptions]" $1`
+8. **Add Issue Comment** (skip if provider is "prompt"):
+   - Read the state management file to get the issue key and provider
+   - If provider is NOT "prompt": Use the Skill tool to execute `/create-comment [issue-key] "[specification details and assumptions]" $1`
+
+9. Specification sign-off is complete


### PR DESCRIPTION
## Summary
- Make step 8 (Add Issue Comment) conditional on provider not being "prompt"
- Add completion message to signal workflow can continue
- Bump version to 1.3.1

## Test plan
- [ ] Run `/feature` with `--provider=prompt` and verify specification sign-off completes without getting stuck
- [ ] Verify workflow continues to git checkout step after approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated to version 1.3.1

* **Bug Fixes**
  * Specification sign-off workflow now includes conditional step execution and completion notification

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->